### PR TITLE
updated to tf v0.9

### DIFF
--- a/src/API/TfRnnCell.jl
+++ b/src/API/TfRnnCell.jl
@@ -3,7 +3,7 @@
 module TfRnnCell
 using PyCall
 @pyimport tensorflow as tf
-@pyimport tensorflow.models.rnn.rnn_cell as tf_rnn_cell
+@pyimport tensorflow.python.ops.rnn_cell as tf_rnn_cell
 import TensorFlow.CoreTypes: *
 using TensorFlow.CoreTypes
 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -4,7 +4,7 @@ module RNN
 using PyCall
 export LSTMCell
 
-@pyimport tensorflow.models.rnn.rnn_cell as rnn_cell
+@pyimport tensorflow.python.ops.rnn_cell as rnn_cell
 
 immutable LSTMCell
   x::PyObject


### PR DESCRIPTION
Minor change to import path for `rnn_cell`. Not backwards compatible with versions below 0.9.
